### PR TITLE
File name 통일 / 불필요한 코드 제거 / cors 설정

### DIFF
--- a/src/main/java/K/HBD/domain/card/controller/CardController.java
+++ b/src/main/java/K/HBD/domain/card/controller/CardController.java
@@ -1,7 +1,7 @@
 package K.HBD.domain.card.controller;
 
-import K.HBD.domain.card.dto.CardDto;
-import K.HBD.domain.card.dto.CardResponseDto;
+import K.HBD.domain.card.dto.request.CardDto;
+import K.HBD.domain.card.dto.response.CardResponseDto;
 import K.HBD.domain.card.service.CardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/K/HBD/domain/card/dto/request/CardDto.java
+++ b/src/main/java/K/HBD/domain/card/dto/request/CardDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 public class CardDto {
-    private String file;
+    private String image;
     private String name;
 }

--- a/src/main/java/K/HBD/domain/card/dto/response/CardResponseDto.java
+++ b/src/main/java/K/HBD/domain/card/dto/response/CardResponseDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class CardResponseDto {
     private String sentence;
     private Emotion emotion;
-    private String image;
+    private String imageUrl;
     private String name;
 
 }

--- a/src/main/java/K/HBD/domain/card/service/Impl/CardServiceImpl.java
+++ b/src/main/java/K/HBD/domain/card/service/Impl/CardServiceImpl.java
@@ -30,11 +30,11 @@ public class CardServiceImpl implements CardService {
     @Override
     @Transactional
     public CardResponseDto responseCard(CardDto card) {
-        EmotionDto emotion = getEmotionFromModel(card.getFile()); // AI 모델 서버에서 가져올 임시 감정
+        EmotionDto emotion = getEmotionFromModel(card.getImage()); // AI 모델 서버에서 가져올 임시 감정
 
         return CardResponseDto.builder()
                 .sentence(sentenceRepository.findLetterByEmotion(emotion.getEmotion()))
-                .image(BASE_URI + card.getFile())
+                .imageUrl(BASE_URI + card.getImage())
                 .name(card.getName())
                 .emotion(emotion.getEmotion())
                 .build();
@@ -43,7 +43,7 @@ public class CardServiceImpl implements CardService {
     private EmotionDto getEmotionFromModel(String imageUrl) {
         return WebClient.create()
                 .post()
-                .uri("http://127.0.0.1:8082/api/model")
+                .uri("http://10.120.72.237:8082/api/model")
                 .accept(MediaType.APPLICATION_JSON)
                 .body(Mono.just(imageUrl), ImageDto.class)
                 .retrieve()

--- a/src/main/java/K/HBD/domain/enumType/Emotion.java
+++ b/src/main/java/K/HBD/domain/enumType/Emotion.java
@@ -2,7 +2,6 @@ package K.HBD.domain.enumType;
 
 public enum Emotion {
     ANGRY, // 분노
-    DISGUST, // 혐오
     FEAR, // 공포
     HAPPY, // 행복
     NEUTRAL, // 무표정

--- a/src/main/java/K/HBD/domain/s3/Impl/AwsS3ServiceImpl.java
+++ b/src/main/java/K/HBD/domain/s3/Impl/AwsS3ServiceImpl.java
@@ -27,24 +27,24 @@ public class AwsS3ServiceImpl implements AwsS3Service {
     private final AmazonS3 amazonS3;
 
     @Override
-    public String uploadFileFromS3(MultipartFile file) {
-        String fileName = "";
-        multipartFileIsNullCheck(file);
+    public String uploadFileFromS3(MultipartFile image) {
+        String imageName = "";
+        multipartFileIsNullCheck(image);
 
-        String imageName = file.getOriginalFilename();
+        String imageOriginalName = image.getOriginalFilename();
 
-        fileName = createFileName(imageName);
+        imageName = createFileName(imageOriginalName);
 
-        ObjectMetadata om = setObjectMetadata(file);
+        ObjectMetadata om = setObjectMetadata(image);
 
-        putS3(file, fileName, om);
+        putS3(image, imageName, om);
 
-        return fileName;
+        return imageName;
     }
 
-    private void putS3(MultipartFile file, String fileName, ObjectMetadata om) {
-        try (InputStream inputStream = file.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, om)
+    private void putS3(MultipartFile image, String imageName, ObjectMetadata om) {
+        try (InputStream inputStream = image.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, imageName, inputStream, om)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
             throw new CustomException(FAILED_SAVE_IMAGE);
@@ -57,22 +57,22 @@ public class AwsS3ServiceImpl implements AwsS3Service {
         }
     }
 
-    private String createFileName(String fileName) {
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    private String createFileName(String imageName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(imageName));
     }
 
-    private String getFileExtension(String fileName) {
+    private String getFileExtension(String imageName) {
         try {
-            return fileName.substring(fileName.lastIndexOf("."));
+            return imageName.substring(imageName.lastIndexOf("."));
         } catch (StringIndexOutOfBoundsException e) {
             throw new CustomException(OUT_OF_STRING_INDEX);
         }
     }
 
-    private ObjectMetadata setObjectMetadata(MultipartFile file) {
+    private ObjectMetadata setObjectMetadata(MultipartFile image) {
         ObjectMetadata om = new ObjectMetadata();
-        om.setContentLength(file.getSize());
-        om.setContentType(file.getContentType());
+        om.setContentLength(image.getSize());
+        om.setContentType(image.getContentType());
 
         return om;
     }

--- a/src/main/java/K/HBD/domain/s3/controller/AwsS3Controller.java
+++ b/src/main/java/K/HBD/domain/s3/controller/AwsS3Controller.java
@@ -13,13 +13,13 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/s3")
+@RequestMapping("/v1/api/s3")
 public class AwsS3Controller {
 
     private final AwsS3Service awsS3Service;
 
     @PostMapping("/image")
-    public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile multipartFile) throws IOException {
+    public ResponseEntity<String> uploadFile(@RequestParam("image") MultipartFile multipartFile) throws IOException {
         return ResponseEntity.ok(awsS3Service.uploadFileFromS3(multipartFile));
     }
 }

--- a/src/main/java/K/HBD/domain/sentence/controller/SentenceController.java
+++ b/src/main/java/K/HBD/domain/sentence/controller/SentenceController.java
@@ -1,6 +1,6 @@
 package K.HBD.domain.sentence.controller;
 
-import K.HBD.domain.sentence.dto.SentenceDto;
+import K.HBD.domain.sentence.dto.request.SentenceDto;
 import K.HBD.domain.sentence.service.SentenceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/sentence")
+@RequestMapping("/v1/api/sentence")
 public class SentenceController {
     private final SentenceService sentenceService;
 

--- a/src/main/java/K/HBD/domain/sentence/dto/request/SentenceDto.java
+++ b/src/main/java/K/HBD/domain/sentence/dto/request/SentenceDto.java
@@ -1,4 +1,4 @@
-package K.HBD.domain.sentence.dto;
+package K.HBD.domain.sentence.dto.request;
 
 import K.HBD.domain.enumType.Emotion;
 import lombok.AllArgsConstructor;

--- a/src/main/java/K/HBD/domain/sentence/service/Impl/SentenceServiceImpl.java
+++ b/src/main/java/K/HBD/domain/sentence/service/Impl/SentenceServiceImpl.java
@@ -1,7 +1,7 @@
 package K.HBD.domain.sentence.service.Impl;
 
 import K.HBD.domain.sentence.Sentence;
-import K.HBD.domain.sentence.dto.SentenceDto;
+import K.HBD.domain.sentence.dto.request.SentenceDto;
 import K.HBD.domain.sentence.repository.SentenceRepository;
 import K.HBD.domain.sentence.service.SentenceService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/K/HBD/domain/sentence/service/SentenceService.java
+++ b/src/main/java/K/HBD/domain/sentence/service/SentenceService.java
@@ -1,6 +1,6 @@
 package K.HBD.domain.sentence.service;
 
-import K.HBD.domain.sentence.dto.SentenceDto;
+import K.HBD.domain.sentence.dto.request.SentenceDto;
 
 public interface SentenceService {
     void addSentence(SentenceDto sentenceDto);

--- a/src/main/java/K/HBD/global/config/querydsl/QuerydslConfig.java
+++ b/src/main/java/K/HBD/global/config/querydsl/QuerydslConfig.java
@@ -1,14 +1,11 @@
 package K.HBD.global.config.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.querydsl.jpa.impl.JPAUpdateClause;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-
-import static K.HBD.domain.sentence.QSentence.sentence;
 
 @Configuration
 public class QuerydslConfig {
@@ -19,10 +16,5 @@ public class QuerydslConfig {
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
         return new JPAQueryFactory(entityManager);
-    }
-
-    @Bean
-    public JPAUpdateClause jpaUpdateClause() {
-        return new JPAUpdateClause(entityManager, sentence);
     }
 }

--- a/src/main/java/K/HBD/global/config/sentence/SetSentence.java
+++ b/src/main/java/K/HBD/global/config/sentence/SetSentence.java
@@ -3,9 +3,8 @@ package K.HBD.global.config.sentence;
 
 import K.HBD.domain.enumType.Emotion;
 import K.HBD.domain.sentence.Sentence;
-import K.HBD.domain.sentence.dto.SentenceDto;
+import K.HBD.domain.sentence.dto.request.SentenceDto;
 import K.HBD.domain.sentence.repository.SentenceRepository;
-import K.HBD.domain.sentence.service.SentenceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,11 +26,6 @@ public class SetSentence {
                 "모든 나무의 열매들은 온전히 무르익기까지 오랜 시간이 걸린다. 당신 또한 그렇다. 지금 당신의 나무의 열매가 온전히 무르익지 않은 것은 아직 때가 되지 않았단 뜻이다. 언제가 될 진 모르지만, 당신의 나무에도 필히 열매가 맺고 무르익을 것이다.",
                 "당신을 아프게 하는 것들이 당신에게 상처를 내더라도 당신의 상처는 결국 아문다. 견디지 않아도 된다. 어차피 아물 상처니까."
         );
-
-        getListSentenceDto(Emotion.DISGUST,
-                "모든 사람과의 관계가 좋을 필요는 없다. 하지만 굳이 사람과의 관계가 나쁠 필요도 없다.",
-                "당신이 특정 대상을 혐오하는 만큼, 그 모습을 바라보는 대상은 당신을 혐오할 것이다."
-                );
 
         saveSentence(listSentenceDto);
 

--- a/src/main/java/K/HBD/global/config/web/WebConfig.java
+++ b/src/main/java/K/HBD/global/config/web/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:8080")
+                .allowedOrigins("http://localhost:8080", "http://3.37.160.189:8080", "http://3.37.160.189:80", "http://10.120.72.237:8080")
                 .allowedMethods(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),

--- a/src/main/java/K/HBD/global/config/web/WebConfig.java
+++ b/src/main/java/K/HBD/global/config/web/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
         corsRegistry.addMapping("/**")
-                .allowedOrigins("http://localhost:8080", "http://3.37.160.189:8080", "http://3.37.160.189:80", "http://10.120.72.237:8080")
+                .allowedOrigins("http://localhost:8080", "http://10.120.72.237:8080")
                 .allowedMethods(
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),


### PR DESCRIPTION
# 작업 사항
_이 번 작업은 리팩토링이 대부분입니다._

## Comments of Commit

### DEL

- __DEL | 불필요한 Emotion 의 DISGUST 제거__ : 모델에서 DISGUST란 감정을 제외하였기에 해당 type을 제거하였습니다.
- __DEL | 사용하지 않는 코드 삭제__ : DISGUST가 제거되었으므로 `SetSentence` 에서 사용하던 DISGUST 관련 코드를 제거하였습니다. / 구문 조회 로직을 변경하였으므로 사용하지 않는 queryDsl update factory를 제거하였습니다.
- __DEL | AWS IP 삭제__ : AWS를 사용하지 못해 AWS IP를 제거하였습니다.

### ADD
- __ADD | CORS 설정 추가__ : 현재 장고 프로젝트가 학교 서버 위에 올라가 있고, 스프링 프로젝트는 AWS 에 올라가 있습니다. 하지만 학교 서버는 외부 IP로 접근이 불가능 해 스프링 프로젝트 또한 학교 서버에도 올라가 있는 상태입니다. 
장고 서버를 AWS에 올리지 않는 다면 스프링과 장고 모두 학교 서버에 올리는 현재 방식을 택해야 할 것 같습니다.

__참고 | 하지만 학교 서버에 저희 서비스가 올라가게 되면 학교에서 할당 받은 IP를 제외한 외부 IP로는 접근이 되지 않아 애플리케이션 배포가 안될 것 같습니다. 또한 학교 서버에 있기 때문에 안드로이드와의 연동이 가능할 지 모르겠습니다.__

`http://10.120.72.237:8080` : 학교 서버 IP

현재 @w00kipop 님과 학교 서버에서 외부 IP를 접근 할 수 있는 방법을 찾고 있습니다. 해당 이슈가 해결 되면 애플리케이션 배포도 이루어질 것 같습니다__

### REF
- __REF | 필드의 이름 통일 / 변경에 따른 작업사항__ : dto나 서비스 단에서 사용하는 필드의 이름을 모두 통일 하였습니다. 또한 변경에 따른 작업 사항도 처리했습니다.